### PR TITLE
Add build dependencies for Ubuntu 12.04

### DIFF
--- a/README.html
+++ b/README.html
@@ -87,7 +87,16 @@
       yum install -y scons git python-lxml wget gcc path make unzip
     flex bison gcc-c++ openssl-devel autoconf automake vim
     python-devel python-setuptools
-	</div>
+  </div>
+      <p>
+        On Ubuntu 12.04 the build dependencies can be installed by 
+        the following command:
+      </p>
+      <div class="well">
+        apt-get install -y scons git python-lxml wget gcc path make unzip
+        flex bison g++ libssl-dev autoconf automake libtool pkg-config vim
+        python-dev python-setuptools
+	    </div>
     </div>
 
     <div class="container">


### PR DESCRIPTION
The following are required to successfully compile contrail-vnc on Ubuntu 12.04 systems.
