### PR TITLE
Remove non-existent package path from Ubuntu dependencies

### DIFF
--- a/README.html
+++ b/README.html
@@ -93,7 +93,7 @@
         the following command:
       </p>
       <div class="well">
-        apt-get install -y scons git python-lxml wget gcc path make unzip
+        apt-get install -y scons git python-lxml wget gcc make unzip
         flex bison g++ libssl-dev autoconf automake libtool pkg-config vim
         python-dev python-setuptools
 	    </div>


### PR DESCRIPTION
You can now simply paste this command into your shell to get all of the build dependencies.
