### PR TITLE
fixed typo for 'patch' for failing builds on minimal Linux installs

### DIFF
--- a/README.html
+++ b/README.html
@@ -84,7 +84,7 @@
     installed by the
     following command:</p>
       <div class="well">
-      yum install -y scons git python-lxml wget gcc path make unzip
+      yum install -y scons git python-lxml wget gcc patch make unzip
     flex bison gcc-c++ openssl-devel autoconf automake vim
     python-devel python-setuptools
   </div>
@@ -93,7 +93,7 @@
         the following command:
       </p>
       <div class="well">
-        apt-get install -y scons git python-lxml wget gcc path make unzip
+        apt-get install -y scons git python-lxml wget gcc patch make unzip
         flex bison g++ libssl-dev autoconf automake libtool pkg-config vim
         python-dev python-setuptools
 	    </div>


### PR DESCRIPTION
I noticed this on my minimal CentOS and Fedora systems - all of my Ubuntu (desktops, Vagrant boxes, etc.) had patch installed by default.  I was just removing 'path' as unnecessary, and realized what was happening during Chef cookbook testing.

```
boost_1_48_0/tools/wave/
boost_1_48_0/tools/wave/build/
boost_1_48_0/tools/wave/build/Jamfile.v2
boost_1_48_0/tools/wave/cpp.cpp
boost_1_48_0/tools/wave/cpp.hpp
boost_1_48_0/tools/wave/cpp_config.hpp
boost_1_48_0/tools/wave/cpp_version.hpp
boost_1_48_0/tools/wave/stop_watch.hpp
boost_1_48_0/tools/wave/trace_macro_expansion.hpp
Traceback (most recent call last):
  File "/usr/lib64/python2.7/pdb.py", line 1314, in main
    pdb._runscript(mainpyfile)
  File "/usr/lib64/python2.7/pdb.py", line 1233, in _runscript
    self.run(statement)
  File "/usr/lib64/python2.7/bdb.py", line 387, in run
    exec cmd in globals, locals
  File "<string>", line 1, in <module>
  File "fetch_packages.py", line 5, in <module>
    import os
  File "fetch_packages.py", line 139, in main
    ProcessPackage(object)
  File "fetch_packages.py", line 131, in ProcessPackage
    ApplyPatches(pkg)
  File "fetch_packages.py", line 60, in ApplyPatches
    proc = subprocess.Popen(cmd, stdin = fp)
  File "/usr/lib64/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1249, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
> /usr/lib64/python2.7/subprocess.py(1249)_execute_child()
-> raise child_exception

def ApplyPatches(pkg):
    stree = pkg.find('patches')
    if stree is None:
        return
    for patch in stree.getchildren():
        cmd = ['patch']
        if patch.get('strip'):
            cmd.append('-p')
            cmd.append(patch.get('strip'))
        if _OPT_VERBOSE:
            print "Patching %s <%s..." % (' '.join(cmd), str(patch))
        if not _OPT_DRY_RUN:
            fp = open(str(patch), 'r')
            proc = subprocess.Popen(cmd, stdin = fp)
            proc.communicate()
```
