### PR TITLE
Add noauth-packaging repo config. file

### DIFF
--- a/noauth-packaging.xml
+++ b/noauth-packaging.xml
@@ -1,0 +1,17 @@
+<manifest>
+<remote name="github" fetch="https://github.com/Juniper"/>
+
+<default revision="refs/heads/master" remote="github"/>
+
+<project name="contrail-build" remote="github" path="tools/build">
+  <copyfile src="SConstruct" dest="SConstruct"/>
+</project>
+<project name="contrail-controller" remote="github" path="controller"/>
+<project name="contrail-vrouter" remote="github" revision="refs/heads/dkms" path="vrouter"/>
+<project name="contrail-third-party" remote="github" path="third_party"/>
+<project name="contrail-generateDS" remote="github" path="tools/generateds"/>
+<project name="contrail-sandesh" remote="github" path="tools/sandesh"/>
+<project name="contrail-packages" remote="github" path="tools/packages"/>
+<project name="contrail-nova-vif-driver" remote="github" path="openstack/nova_contrail_vif"/>
+
+</manifest>


### PR DESCRIPTION
Hi, (I worked on debian packaging for OpenContrail),

```
It's preferable to use dkms to build the vrouter.ko kernel module
(part of the construction of deb packages), this commit just adds a new
noauth configuration file (pointing to the dkms branch of vrouter repo).
```
