### PR TITLE
Fixed: webui unit tests failures on CI

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -17,6 +17,8 @@
 <project name="contrail-nova-vif-driver" remote="github" path="openstack/nova_contrail_vif"/>
 <project name="contrail-neutron-plugin" remote="github" path="openstack/neutron_plugin"/>
 <project name="contrail-nova-extensions" remote="github" path="openstack/nova_extensions"/>
+<project name="contrail-web-storage" remote="github"/>
+<project name="contrail-web-server-manager" remote="github"/>
 <project name="contrail-web-controller" remote="github"/>
 <project name="contrail-web-core" remote="github"/>
 <project name="contrail-webui-third-party" remote="github" path="contrail-webui-third-party"/>


### PR DESCRIPTION
The reason for these failures is that CI is using contrail-vnc manifest for unit tests [and not contrail-vnc-private] and to run webui unit-test's we need contrail-web-storage and contrail-web-server-manager repo.