### PR TITLE
Add new repositories to contrail-vnc to match recent changes

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,10 +12,14 @@
 <project name="contrail-generateDS" remote="github" path="tools/generateds"/>
 <project name="contrail-sandesh" remote="github" path="tools/sandesh"/>
 <project name="contrail-common" remote="github" path="src/contrail-common"/>
+<project name="contrail-analytics" remote="github" path="src/contrail-analytics"/>
 <project name="contrail-api-client" remote="github" path="src/contrail-api-client"/>
+<!-- Packages are split between contrail-packages and contrail-packaging -->
 <project name="contrail-packages" remote="github" path="tools/packages">
   <copyfile src="packages.make" dest="packages.make"/>
 </project>
+<project name="contrail-packaging" remote="github" path="tools/packaging"/>
+<project name="contrail-provisioning" remote="github" path="tools/provisioning"/>
 <project name="contrail-nova-vif-driver" remote="github" path="openstack/nova_contrail_vif"/>
 <project name="contrail-neutron-plugin" remote="github" path="openstack/neutron_plugin"/>
 <project name="contrail-nova-extensions" remote="github" path="openstack/nova_extensions"/>
@@ -25,6 +29,9 @@
 <project name="contrail-web-controller" remote="github"/>
 <project name="contrail-web-core" remote="github"/>
 <project name="contrail-webui-third-party" remote="github" path="contrail-webui-third-party"/>
+<!-- Used by OpenContrail CI jobs -->
+<project name="contrail-fabric-utils" remote="github" path="third_party/fabric-utils" />
+<project name="contrail-test" remote="github" path="third_party/contrail-test" />
 
 </manifest>
 


### PR DESCRIPTION
Between repo split effort and new CentOS 7.4 packaging jobs, we need to add some additional repositories to contrail-vnc manifest, 